### PR TITLE
Fix type opts.getObjetRef to opts.getObjectRef

### DIFF
--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -196,7 +196,7 @@ export default class ReplaceSupers {
   isLoose: boolean;
   file;
   opts: {
-    getObjetRef: Function,
+    getObjectRef: Function,
     methodPath: NodePath,
     superRef: Object,
     isLoose: boolean,


### PR DESCRIPTION
Quick fix.

```NodeJs
  opts: {
    getObjetRef: Function,
    methodPath: NodePath,
    superRef: Object,
    isLoose: boolean,
    file: any,
  };
```
Should be:

```Nodejs
  opts: {
    getObjectRef: Function,
    methodPath: NodePath,
    superRef: Object,
    isLoose: boolean,
    file: any,
  };
```

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
